### PR TITLE
ramdisk: enable interactive features for array-parameters

### DIFF
--- a/profiles/ramdisk/init.mapphone_umts.rc
+++ b/profiles/ramdisk/init.mapphone_umts.rc
@@ -204,6 +204,12 @@ on boot
     chown system system /sys/devices/system/cpu/cpufreq/interactive/input_boost
     chmod 0660 /sys/devices/system/cpu/cpufreq/interactive/input_boost
 
+    # Interactive Tunables
+    chmod 0664 /sys/devices/system/cpu/cpufreq/interactive/target_loads
+    chmod 0664 /sys/devices/system/cpu/cpufreq/interactive/above_hispeed_delay
+    write /sys/devices/system/cpu/cpufreq/interactive/target_loads "95 600000:50"
+    write /sys/devices/system/cpu/cpufreq/interactive/above_hispeed_delay "20000 600000:40000" 
+
     # Charge only mode services.
     exec /system/bin/mot_boot_mode
     class_start charger


### PR DESCRIPTION
Our interactive governor is capable of arrays in some
parameters, however if they aren't set at boot some apps
can't change them in realtime (like AeroControl).

This change enables this feature. Furthermore it may help
with the in-call delay a little bit.

Signed-off-by: Blechd0se alex.christ@hotmail.de
