### PR TITLE
Proper removal of battery stats

### DIFF
--- a/prebuilt/etc/init.d/80battd
+++ b/prebuilt/etc/init.d/80battd
@@ -2,4 +2,13 @@
 #
 # Remove battd stats
 
-rm -rf /data/battd
+battd_dir=/data/battd
+battd_uid=$(ps $(pidof battd)|tail -1|cut -d ' ' -f 1)
+
+if [ -d $battd_dir ]; then
+   rm -rf $battd_dir/*
+else
+   mkdir $battd_dir
+   chown $battd_uid $battd_dir
+   chmod 0770 $battd_dir
+fi


### PR DESCRIPTION
This fixes battd not being able to read/write to /data/battd/ as it expects the directory to already exist. Credit for the change goes to XDA's YetAnotherForumUser [http://forum.xda-developers.com/showpost.php?p=50604566&postcount=2884]
