### PR TITLE
Fixed building wifi modules on some systems

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -183,14 +183,14 @@ TARGET_RELEASETOOL_OTA_FROM_TARGET_SCRIPT := build/tools/releasetools/ota_from_t
 TARGET_SYSTEMIMAGE_USE_SQUISHER := true
 
 ext_modules:
-	make -C $(TARGET_KERNEL_MODULES_EXT) modules KERNEL_DIR=$(KERNEL_OUT) ARCH=arm CROSS_COMPILE="arm-eabi-"
+	make -C $(TARGET_KERNEL_MODULES_EXT) modules KERNEL_DIR=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE)
 	find $(TARGET_KERNEL_MODULES_EXT)/ -name "*.ko" -exec mv {} \
 		$(KERNEL_MODULES_OUT) \; || true
 
 COMPAT_MODULES:
-	make mrproper -C device/moto/jordan-common/modules/backports
-	make -C device/moto/jordan-common/modules/backports KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=arm CROSS_COMPILE="arm-eabi-" defconfig-mapphone
-	make -C device/moto/jordan-common/modules/backports KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=arm CROSS_COMPILE="arm-eabi-"
+	make -C device/moto/jordan-common/modules/backports KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE) mrproper
+	make -C device/moto/jordan-common/modules/backports KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE) defconfig-mapphone
+	make -C device/moto/jordan-common/modules/backports KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE)
 	mv device/moto/jordan-common/modules/backports/compat/compat.ko $(KERNEL_MODULES_OUT)
 ifeq ($(TARGET_USE_BLUEDROID_STACK),false)
 	mv device/moto/jordan-common/modules/backports/net/bluetooth/bluetooth.ko $(KERNEL_MODULES_OUT)
@@ -208,7 +208,7 @@ endif
 
 WLAN_MODULES:
 	make -C hardware/ti/wlan/mac80211/compat_wl12xx KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE) clean
-	make -C hardware/ti/wlan/mac80211/compat_wl12xx KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=arm CROSS_COMPILE="arm-eabi-"
+	make -C hardware/ti/wlan/mac80211/compat_wl12xx KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE)
 	mv hardware/ti/wlan/mac80211/compat_wl12xx/compat/compat.ko $(KERNEL_MODULES_OUT)
 	mv hardware/ti/wlan/mac80211/compat_wl12xx/net/mac80211/mac80211.ko $(KERNEL_MODULES_OUT)
 	mv hardware/ti/wlan/mac80211/compat_wl12xx/net/wireless/cfg80211.ko $(KERNEL_MODULES_OUT)
@@ -217,10 +217,10 @@ WLAN_MODULES:
 	arm-linux-androideabi-strip --strip-unneeded $(KERNEL_MODULES_OUT)/*
 
 hboot:
-	mkdir -p $(PRODUCT_OUT)/system/bootstrap/2nd-boot   
-	make -C  $(ANDROID_BUILD_TOP)/device/moto/jordan-common/bootstrap/hboot ARCH=arm CROSS_COMPILE="arm-eabi-"
+	mkdir -p $(PRODUCT_OUT)/system/bootstrap/2nd-boot
+	make -C  $(ANDROID_BUILD_TOP)/device/moto/jordan-common/bootstrap/hboot ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE)
 	mv $(ANDROID_BUILD_TOP)/device/moto/jordan-common/bootstrap/hboot/hboot.bin $(PRODUCT_OUT)/system/bootstrap/2nd-boot/
-	make clean -C $(ANDROID_BUILD_TOP)/device/moto/jordan-common/bootstrap/hboot
+	make -C $(ANDROID_BUILD_TOP)/device/moto/jordan-common/bootstrap/hboot ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE) clean
 
 # If kernel sources are present in repo, here is the location
 TARGET_KERNEL_SOURCE := $(ANDROID_BUILD_TOP)/jordan-kernel

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -207,7 +207,7 @@ endif
 	arm-linux-androideabi-strip --strip-unneeded $(KERNEL_MODULES_OUT)/*
 
 WLAN_MODULES:
-	make clean -C hardware/ti/wlan/mac80211/compat_wl12xx
+	make -C hardware/ti/wlan/mac80211/compat_wl12xx KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=$(TARGET_ARCH) $(ARM_CROSS_COMPILE) clean
 	make -C hardware/ti/wlan/mac80211/compat_wl12xx KERNEL_DIR=$(KERNEL_OUT) KLIB=$(KERNEL_OUT) KLIB_BUILD=$(KERNEL_OUT) ARCH=arm CROSS_COMPILE="arm-eabi-"
 	mv hardware/ti/wlan/mac80211/compat_wl12xx/compat/compat.ko $(KERNEL_MODULES_OUT)
 	mv hardware/ti/wlan/mac80211/compat_wl12xx/net/mac80211/mac80211.ko $(KERNEL_MODULES_OUT)

--- a/releasetools/jordan-common_ota_from_target_files.py
+++ b/releasetools/jordan-common_ota_from_target_files.py
@@ -48,14 +48,14 @@ def FullOTA_InstallEnd(self, *args, **kwargs):
 def FullOTA_DisableBootImageInstallation(self, *args, **kwargs):
   return True
 
+def FullOTA_DisableRecoveryUpdate(self, *args, **kwargs):
+  return True
+
 def FullOTA_FormatSystemPartition(self, *args, **kwargs):
   self.script.Mount("/system")
   self.script.AppendExtra('delete_recursive("/system");')
 
   # returning true skips formatting /system!
-  return True
-
-def IncrementalOTA_DisableRecoveryUpdate(self, *args, **kwargs):
   return True
 
 def IncrementalOTA_InstallEnd(self, *args, **kwargs):


### PR DESCRIPTION
The hosts KERNEL_DIR/KLIB_BUILD was used during "make clean" -> EVIL!

```
....
make clean -C hardware/ti/wlan/mac80211/compat_wl12xx
make[1]: Entering directory '/hardware/ti/wlan/mac80211/compat_wl12xx'
/hardware/ti/wlan/mac80211/compat_wl12xx/config.mk:256: "WARNING: CONFIG_CFG80211_WEXT will be deactivated or not working because kernel was compiled with CONFIG_WIRELESS_EXT=n. Tools using wext interface like iwconfig will not work. To activate it build your kernel e.g. with CONFIG_LIBIPW=m."
/sbin/modprobe: invalid option -- 'l'
/sbin/modprobe: invalid option -- 'l'
make[2]: Entering directory '/usr/lib/modules/3.14.4-1-ARCH/build'
make[2]: *** No rule to make target 'clean'.  Stop.
make[2]: Leaving directory '/usr/lib/modules/3.14.4-1-ARCH/build'
Makefile:443: recipe for target 'clean' failed
make[1]: *** [clean] Error 2
make[1]: Leaving directory '/hardware/ti/wlan/mac80211/compat_wl12xx'
device/moto/jordan-common/BoardConfig.mk:210: recipe for target 'WLAN_MODULES' failed
make: *** [WLAN_MODULES] Error 2
$
```
