### PR TITLE
Rename "DisableRecoveryUpdate" in 2.6.32 branch

### DIFF
--- a/releasetools/jordan-common_ota_from_target_files.py
+++ b/releasetools/jordan-common_ota_from_target_files.py
@@ -48,14 +48,14 @@ def FullOTA_InstallEnd(self, *args, **kwargs):
 def FullOTA_DisableBootImageInstallation(self, *args, **kwargs):
   return True
 
+def FullOTA_DisableRecoveryUpdate(self, *args, **kwargs):
+  return True
+
 def FullOTA_FormatSystemPartition(self, *args, **kwargs):
   self.script.Mount("/system")
   self.script.AppendExtra('delete_recursive("/system");')
 
   # returning true skips formatting /system!
-  return True
-
-def IncrementalOTA_DisableRecoveryUpdate(self, *args, **kwargs):
   return True
 
 def IncrementalOTA_InstallEnd(self, *args, **kwargs):


### PR DESCRIPTION
This change is required to get 2.6.32 building.
The other changes from PR #28 were not cherry-picked as they are not critical - but one could still do that.
