### PR TITLE
Configure TARGET_INCREMENTAL_OTA_VERBATIM_FILES.

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -163,6 +163,7 @@ BOARD_HAL_STATIC_LIBRARIES := libhealthd.omap3
 # Release tool
 TARGET_PROVIDES_RELEASETOOLS := true
 TARGET_RELEASETOOL_OTA_FROM_TARGET_SCRIPT := build/tools/releasetools/ota_from_target_files --device_specific device/moto/jordan-common/releasetools/jordan-common_ota_from_target_files.py
+TARGET_INCREMENTAL_OTA_VERBATIM_FILES := system/app/Provision.apk
 TARGET_SYSTEMIMAGE_USE_SQUISHER := true
 
 ext_modules:


### PR DESCRIPTION
The latest changes in android_build (in either xdarklight's or Quarx2k's
forks) make it possible to configure it on a per-device level.
